### PR TITLE
add used sources in `gcover qa extract`

### DIFF
--- a/src/gcover/cli/qa_cmd.py
+++ b/src/gcover/cli/qa_cmd.py
@@ -1708,6 +1708,13 @@ def _auto_discover_rc_gdbs(base_dir: Path) -> tuple[Optional[Path], Optional[Pat
     help="Use ESRI ArcMap FileGDB format",
 )
 @click.option(
+    "--include-source-layers/--no-source-layers",
+    "include_source_layers",
+    default=True,
+    show_default=True,
+    help="Write the zone layers used (mapsheets_sources_only, qa_rand_gc_buffer_50m) into the output file for provenance.",
+)
+@click.option(
     "--yes", is_flag=True, help="Automatically confirm prompts (for scripting)"
 )
 @click.pass_context
@@ -1720,6 +1727,7 @@ def extract(
     output_format: str,
     filter_by_source: bool,
     rand_border_filter: str,
+    include_source_layers: bool,
     yes: bool,
     asset_type: str,
     use_arcmap: bool,
@@ -1819,6 +1827,7 @@ def extract(
                 output_path=issue_output,
                 output_format=output_format.lower(),
                 rand_buffer_predicate=rand_border_filter,
+                include_source_layers=include_source_layers,
             )
         else:
             logger.warning("Extracting all issues (no source filtering)")

--- a/src/gcover/qa/analyzer.py
+++ b/src/gcover/qa/analyzer.py
@@ -38,6 +38,8 @@ def custom_warning_handler(message, category, filename, lineno, file=None, line=
 
 warnings.showwarning = custom_warning_handler
 
+_RAND_BUFFER_LAYER = "qa_rand_gc_buffer_50m"
+
 
 class QAAnalyzer:
     """
@@ -120,7 +122,7 @@ class QAAnalyzer:
 
             # Optional rand-buffer zone — present only when create-administrative-zones
             # was run with --qa-rand-gc.
-            _RAND_BUFFER_LAYER = "qa_rand_gc_buffer_50m"
+
             try:
                 gdf = gpd.read_file(self.zones_file, layer=_RAND_BUFFER_LAYER)
                 if not gdf.empty:
@@ -301,6 +303,7 @@ class QAAnalyzer:
         output_format: str = "gpkg",
         deduplicate_cross_zone: bool = True,
         rand_buffer_predicate: str = "intersects",
+        include_source_layers: bool = True,
     ) -> Dict[str, int]:
         """
         Extract only relevant QA issues based on mapsheet source mapping.
@@ -322,6 +325,9 @@ class QAAnalyzer:
             output_format: 'gpkg' or 'filegdb'
             deduplicate_cross_zone: Whether to deduplicate features crossing multiple zones
             rand_buffer_predicate: 'intersects', 'within', or 'none'
+            include_source_layers: When True, write the zone layers used
+                (mapsheets_sources_only, and qa_rand_gc_buffer_50m if active)
+                into the output file for provenance.
 
         Returns:
             Dictionary with extraction statistics
@@ -563,8 +569,14 @@ class QAAnalyzer:
             if layer_gdfs:
                 combined_layers[layer_type] = pd.concat(layer_gdfs, ignore_index=True)
 
+        # Optionally append the zone layers used so the output is self-documenting
+        if include_source_layers:
+            combined_layers["mapsheets_sources_only"] = self.zones_data["mapsheets"]
+            if rand_buffer_predicate != "none" and "rand_buffer" in self.zones_data:
+                combined_layers[_RAND_BUFFER_LAYER] = self.zones_data["rand_buffer"]
+            logger.info("Including source zone layers in output for provenance")
+
         # Write output
-        # TODO cleanup temp_merged_RC_combined.gpkg
         output_path.parent.mkdir(parents=True, exist_ok=True)
         self._write_spatial_output(combined_layers, output_path, output_format)
 


### PR DESCRIPTION
Added --include-source-layers flag (default on) to gcover qa extract, which writes mapsheets_sources_only and optionally qa_rand_gc_buffer_50m into the output GPKG for provenance