### PR TITLE
Trying to keep ESRI original Schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ ASPECT_LAYERS := $(strip $(ASPECT_LAYERS))
 
 # File Paths
 MASTER_GDB        ?= $(OUTPUT_DIR)merged_master.gdb
+FINAL_GDB         ?= $(OUTPUT_DIR)merged_final.gdb
 DENORMALIZED_GPKG := denormalized.gpkg
 DENORMALIZED_PATH := $(OUTPUT_DIR)$(DENORMALIZED_GPKG)
 CLASSIFIED_GPKG	  := denormalized_classified.gpkg
@@ -61,7 +62,7 @@ LAYERS := fossils exploit_polygons exploit_points linear_objects point_objects b
 TABLES_TO_IMPORT := GC_GEOL_MAPPING_UNIT GC_GEOL_MAPPING_UNIT_ATT GC_LITSTRAT_FORMATION_BANK GC_CHRONO \
                     GC_EX_GEO_PLG_EXP_UNIT_GC_GMU GC_EX_GEO_PNT_EXP_UNIT_GC_GMU \
                     GC_FOSS_SYSTEM_GC_SYSTEM \
-                    GC_UN_DEP_CHARACT_GC_CHARCAT GC_UN_DEP_COMPOSIT_GC_COMPOS GC_UN_DEP_MAT_TYPE_GC_LITHO
+                    GC_UN_DEP_CHARACT_GC_CHARCAT GC_UN_DEP_COMPOSIT_GC_COMPOS GC_UN_DEP_MAT_TYPE_GC_LITHO GC_UN_DEP_ADMIXTUR_GC_ADMIXT
 
 
 # ANSI color codes
@@ -162,7 +163,8 @@ $(MASTER_GDB)/timestamps: $(DELIVERY_DIR)RC1.gdb $(DELIVERY_DIR)RC2.gdb
 		--custom-sources-dir $(DELIVERY_DIR) \
 		--force-2d --output $(MASTER_GDB) \
 		--no-clip-to-swiss-border \
-		--enrich-mapsheet-links; \
+		--enrich-mapsheet-links \
+		--schema-output $(FINAL_GDB); \
 	rc=$$?; \
 	if [ $$rc -eq 130 ]; then \
 		echo ""; \
@@ -179,11 +181,18 @@ merge-diagnostic:
 
 
 # 2. Add missing tables and Denormalize
+.PHONY: add-tables
+add-tables: $(MASTER_GDB)/timestamps
+		@echo "--- Importing missing tables via ogr2ogr ---"
+		@for table in $(TABLES_TO_IMPORT); do \
+			ogr2ogr -f "OpenFileGDB" -update -overwrite $(MASTER_GDB) $(FULL_GDB_PATH) $$table; \
+		done
+
 $(DENORMALIZED_PATH): $(MASTER_GDB)/timestamps
-	@echo "--- Importing missing tables via ogr2ogr ---"
-	@for table in $(TABLES_TO_IMPORT); do \
-		ogr2ogr -f "OpenFileGDB" -update -overwrite $(MASTER_GDB) $(FULL_GDB_PATH) $$table; \
-	done
+		@echo "--- Importing missing tables via ogr2ogr ---"
+		@for table in $(TABLES_TO_IMPORT); do \
+			ogr2ogr -f "OpenFileGDB" -update -overwrite $(MASTER_GDB) $(FULL_GDB_PATH) $$table; \
+		done
 
 	@echo "--- Running Denormalization loop ---"
 	@for layer in $(LAYERS); do \

--- a/Makefile
+++ b/Makefile
@@ -164,6 +164,7 @@ $(MASTER_GDB)/timestamps: $(DELIVERY_DIR)RC1.gdb $(DELIVERY_DIR)RC2.gdb
 		--force-2d --output $(MASTER_GDB) \
 		--no-clip-to-swiss-border \
 		--enrich-mapsheet-links \
+		--exclude-metadata \
 		--schema-output $(FINAL_GDB); \
 	rc=$$?; \
 	if [ $$rc -eq 130 ]; then \

--- a/scripts/denormalize_geocover.py
+++ b/scripts/denormalize_geocover.py
@@ -615,6 +615,26 @@ class GeoCoverDenormalizer:
         self.coded_domains = extract_coded_domains(cd_gdb_path) # Need a genuine ESRI-GDB :-(
 
 
+    def _read_table(self, table_name: str) -> pd.DataFrame:
+        """Read a non-spatial table, falling back to name_1 for arcpy-copied GDBs.
+
+        arcpy.Copy renames junction tables (GC_EX_GEO_*, GC_UN_DEP_*, etc.) to
+        name_1 when the relationship class and its data table share the same name.
+        """
+        for candidate in (table_name, f"{table_name}_1"):
+            try:
+                df = gpd.read_file(self.gdb_path, layer=candidate)
+                if candidate != table_name:
+                    logger.warning(
+                        f"Read '{candidate}' instead of '{table_name}' (arcpy copy artifact)"
+                    )
+                return df
+            except Exception:
+                continue
+        raise ValueError(
+            f"Could not read table '{table_name}' (tried with and without _1 suffix)"
+        )
+
     def _read_layer_safe(
         self, layer_name: str, group: Optional[str] = "GC_ROCK_BODIES"
     ) -> gpd.GeoDataFrame:
@@ -661,7 +681,7 @@ class GeoCoverDenormalizer:
         # Read tables
         main_gdf = self._read_layer_safe(main_table)
         lookup_df = gpd.read_file(self.gdb_path, layer=lookup_table)
-        relationship_df = gpd.read_file(self.gdb_path, layer=relationship_table)
+        relationship_df = self._read_table(relationship_table)
 
         logger.info(f"Loaded {len(main_gdf)} features from {main_table}")
         logger.info(f"Loaded {len(lookup_df)} records from {lookup_table}")
@@ -1036,9 +1056,7 @@ class GeoCoverDenormalizer:
 
             try:
                 lookup_df = gpd.read_file(self.gdb_path, layer=config["lookup_table"])
-                relationship_df = gpd.read_file(
-                    self.gdb_path, layer=config["relationship_table"]
-                )
+                relationship_df = self._read_table(config["relationship_table"])
 
                 logger.debug(
                     f"{rel_name}: {len(lookup_df)} lookup records, {len(relationship_df)} relationships"

--- a/src/gcover/cli/publish_cmd.py
+++ b/src/gcover/cli/publish_cmd.py
@@ -24,8 +24,8 @@ from rich.table import Table
 from rich.text import Text
 
 from gcover.cli.main import _split_bbox
-from gcover.config import (DEFAULT_EXCLUDED_FIELDS, SDE_INSTANCES, AppConfig,
-                           load_config)
+from gcover.config import (DEFAULT_EXCLUDED_FIELDS, GEOCOVER_METADATA_FIELDS,
+                           SDE_INSTANCES, AppConfig, load_config)
 from gcover.publish.esri_classification_applicator import \
     ClassificationApplicator
 from gcover.publish.esri_classification_extractor import (
@@ -2203,7 +2203,7 @@ def merge(
         reference_source=reference_source,
         mapsheet_numbers=mapsheet_numbers,
         preserve_z=not force_2d,  # If force_2d, don't preserve Z
-        exclude_fields=DEFAULT_EXCLUDED_FIELDS if exclude_metadata else None,
+        exclude_fields=GEOCOVER_METADATA_FIELDS if exclude_metadata else None,
         use_convex_hull_masks=True,
         clip_to_swiss_border=clip_to_swiss_border,
         validate_geometries=validate_geometries,
@@ -2225,7 +2225,7 @@ def merge(
     console.print(f"\n[bold blue]🔀 GeoCover Source Merger[/bold blue]\n")
 
     if exclude_metadata:
-        console.print(f"[dim]Excluding metadata fields: {', '.join(DEFAULT_EXCLUDED_FIELDS)}[/dim]")
+        console.print(f"[dim]Excluding {len(GEOCOVER_METADATA_FIELDS)} metadata fields[/dim]")
 
     if verbose:
         console.print("[dim]Verbose mode enabled[/dim]")
@@ -2294,6 +2294,7 @@ def merge(
                 merged_gdb=output,
                 output_gdb=schema_output,
                 log=console.print,
+                exclude_fields=GEOCOVER_METADATA_FIELDS if exclude_metadata else None,
             )
             if errors:
                 console.print(f"[yellow]Schema patch completed with {len(errors)} error(s):[/yellow]")

--- a/src/gcover/cli/publish_cmd.py
+++ b/src/gcover/cli/publish_cmd.py
@@ -2052,6 +2052,18 @@ def show_sample_data(layer_name: str, sample_gdf: gpd.GeoDataFrame):
     is_flag=True,
     help="Show what would be processed without executing",
 )
+@click.option(
+    "--schema-gdb",
+    type=click.Path(exists=True, path_type=Path),
+    help="Authoritative FileGDB to clone schema from (defaults to --rc2). "
+         "Enables schema-patching when --schema-output is set.",
+)
+@click.option(
+    "--schema-output",
+    type=click.Path(path_type=Path),
+    help="Path for the schema-patched output GDB (preserves ESRI domains & "
+         "relationship classes). Requires --output to be a .gdb file.",
+)
 def merge(
         ctx,
         rc1: Optional[Path],
@@ -2073,6 +2085,8 @@ def merge(
         validate_geometries: bool,
         exclude_metadata: bool,
         dry_run: bool,
+        schema_gdb: Optional[Path],
+        schema_output: Optional[Path],
 ):
     """
     Merge multiple FileGDB sources into a single publication GDB.
@@ -2258,6 +2272,35 @@ def merge(
             import traceback
             console.print(f"[dim]{traceback.format_exc()}[/dim]")
         raise click.Abort()
+
+    # Optional schema-patch step: clone authoritative GDB schema and inject merged data
+    if schema_output is not None:
+        if output.suffix.lower() != ".gdb":
+            console.print("[yellow]--schema-output ignored: --output must be a .gdb file[/yellow]")
+        else:
+            effective_schema = schema_gdb or rc2
+            if effective_schema is None:
+                console.print("[red]--schema-output requires --schema-gdb or --rc2 to be set[/red]")
+                raise click.Abort()
+
+            console.print(f"\n[bold blue]Schema patch[/bold blue]")
+            console.print(f"  schema : {effective_schema}")
+            console.print(f"  merged : {output}")
+            console.print(f"  output : {schema_output}")
+
+            from gcover.publish.patch_schema import patch_schema_gdb
+            errors = patch_schema_gdb(
+                schema_gdb=effective_schema,
+                merged_gdb=output,
+                output_gdb=schema_output,
+                log=console.print,
+            )
+            if errors:
+                console.print(f"[yellow]Schema patch completed with {len(errors)} error(s):[/yellow]")
+                for e in errors:
+                    console.print(f"  [yellow]• {e}[/yellow]")
+            else:
+                console.print("[bold green]Schema patch completed successfully.[/bold green]")
 
 
 def _display_merge_config(config: MergeConfig, dry_run: bool) -> None:

--- a/src/gcover/config/__init__.py
+++ b/src/gcover/config/__init__.py
@@ -147,6 +147,27 @@ DEFAULT_EXCLUDED_FIELDS = {
     "Shape_Area",
 }
 
+# Union of DEFAULT_EXCLUDED_FIELDS and the GeoCover-specific operational
+# metadata fields stripped by denormalize_geocover.py clean_metadata_columns().
+GEOCOVER_METADATA_FIELDS = DEFAULT_EXCLUDED_FIELDS | {
+    "INTEGRATION_OBJECT_UUID",
+    "OPERATOR",
+    "DATEOFCHANGE",
+    "DATEOFCREATION",
+    "ORIGINAL_ORIGIN",
+    "REASONFORCHANGE",
+    "REVISION_QUALITY",
+    "OBJECTORIGIN_MONTH",
+    "OBJECTORIGIN_YEAR",
+    "RC_ID_CREATION",
+    "RC_ID",
+    "WU_ID_CREATION",
+    "WU_ID",
+    "TREE_LEVEL",
+    "SHAPE_Area",   # uppercase variant used in GDB layers
+    "SHAPE_Length",
+}
+
 __all__ = [
     "AppConfig",
     "GlobalConfig",
@@ -159,6 +180,7 @@ __all__ = [
     "debug_config_loading",
     "EXCLUDED_TABLES",
     "DEFAULT_EXCLUDED_FIELDS",
+    "GEOCOVER_METADATA_FIELDS",
     "SDE_INSTANCES",
     "DEFAULT_VERSIONS",
     "DEFAULT_CHUNK_SIZE",

--- a/src/gcover/publish/patch_schema.py
+++ b/src/gcover/publish/patch_schema.py
@@ -155,6 +155,7 @@ def patch_schema_gdb(
     merged_gdb: Path,
     output_gdb: Path,
     log: Callable[[str], None] = print,
+    exclude_fields: set[str] | None = None,
 ) -> list[str]:
     """Clone schema_gdb, then replace its data with content from merged_gdb.
 
@@ -169,6 +170,10 @@ def patch_schema_gdb(
         Destination path.  Deleted and recreated if it already exists.
     log:
         Callable used for progress reporting (default: print).
+    exclude_fields:
+        Field names to drop from every spatial layer in the clone before
+        appending data.  Pass GEOCOVER_METADATA_FIELDS to mirror the
+        --exclude-metadata behaviour of the merge step.
 
     Returns
     -------
@@ -205,7 +210,7 @@ def patch_schema_gdb(
     log(f"  layers: {ds.GetLayerCount()},  domains: {len(ds.GetFieldDomainNames() or [])}")
     ds = None
 
-    # Step 1b: add extra fields absent from schema GDB
+    # Step 1b: add extra fields absent from schema GDB / drop excluded fields
     ds = ogr.Open(output_gdb, 1)
     for layer_name in SPATIAL_LAYERS:
         lyr = ds.GetLayerByName(layer_name)
@@ -217,6 +222,16 @@ def patch_schema_gdb(
             if fname not in existing:
                 lyr.CreateField(ogr.FieldDefn(fname, ftype))
                 log(f"  added field '{fname}' to {layer_name}")
+        if exclude_fields:
+            # Delete fields in reverse index order to keep indices stable
+            to_drop = [
+                i for i in range(defn.GetFieldCount())
+                if defn.GetFieldDefn(i).GetName() in exclude_fields
+            ]
+            for i in reversed(to_drop):
+                lyr.DeleteField(i)
+            if to_drop:
+                log(f"  dropped {len(to_drop)} metadata fields from {layer_name}")
     ds = None
 
     # Steps 2 & 3: patch spatial layers and tables

--- a/src/gcover/publish/patch_schema.py
+++ b/src/gcover/publish/patch_schema.py
@@ -1,0 +1,229 @@
+"""
+patch_schema.py — clone an authoritative ESRI FileGDB schema and inject
+merged spatial data into it, preserving coded domains, relationship classes,
+and the GC_ROCK_BODIES feature dataset.
+
+Strategy
+--------
+  1. shutil.copytree  — byte-perfect clone: domains, relationship classes,
+                        feature dataset and topology layers all survive.
+  2. OGR update mode  — delete all features from each target layer.
+  3. gdal.VectorTranslate (accessMode='append') — bulk-write from the
+                        geopandas-merged GDB; much faster than a Python loop.
+  4. CreateField      — add extra fields present in merged_gdb but absent
+                        from the schema clone (e.g. _MERGE_SOURCE, erl_link).
+
+Tested with GDAL 3.10.3 and GDAL 3.13.0.
+"""
+from __future__ import annotations
+
+import shutil
+import time
+from pathlib import Path
+from typing import Callable
+
+from osgeo import gdal, ogr
+
+gdal.UseExceptions()
+
+SPATIAL_LAYERS = [
+    "GC_BEDROCK",
+    "GC_UNCO_DESPOSIT",
+    "GC_SURFACES",
+    "GC_LINEAR_OBJECTS",
+    "GC_POINT_OBJECTS",
+    "GC_FOSSILS",
+    "GC_EXPLOIT_GEOMAT_PLG",
+    "GC_EXPLOIT_GEOMAT_PT",
+]
+
+TABLE_LAYERS = [
+    "GC_GEOL_MAPPING_UNIT",
+    "GC_GEOL_MAPPING_UNIT_ATT",
+    "GC_SYSTEM",
+    "GC_COMPOSIT",
+    "GC_ADMIXTURE",
+    "GC_CHARCAT",
+    "GC_LITHO",
+    "GC_CHRONO",
+    "GC_TECTO",
+    "GC_LITHO_UNCO",
+    "GC_LITSTRAT_UNCO",
+    "GC_CORRELATION",
+    "GC_LITSTRAT_FORMATION_BANK",
+    "GC_EX_GEO_PLG_EXP_UNIT_GC_GMU",
+    "GC_EX_GEO_PNT_EXP_UNIT_GC_GMU",
+    "GC_FOSS_SYSTEM_GC_SYSTEM",
+    "GC_UN_DEP_CHARACT_GC_CHARCAT",
+    "GC_UN_DEP_COMPOSIT_GC_COMPOS",
+    "GC_UN_DEP_MAT_TYPE_GC_LITHO",
+]
+
+# Topology layers dropped from the publication GDB.
+# GC_UN_DEP_ADMIXTUR_GC_ADMIXT is intentionally absent: kept from the clone
+# because geopandas drops it entirely.
+_DROP_LAYERS: frozenset[str] = frozenset({"BEDROCK_TOPOLOGY", "GC_ROCK_BODIES_TOPO"})
+_DROP_PREFIXES: tuple[str, ...] = ("T_1_",)
+
+# Fields present in merged GDB but absent from the authoritative schema GDB.
+_EXTRA_FIELDS: list[tuple[str, int]] = [
+    ("_MERGE_SOURCE", ogr.OFTString),
+    ("erl_link",      ogr.OFTString),
+    ("ber_link",      ogr.OFTString),
+]
+
+
+def _truncate(ds: ogr.DataSource, name: str) -> int:
+    lyr = ds.GetLayerByName(name)
+    if lyr is None:
+        return -1
+    fids = [f.GetFID() for f in lyr]
+    lyr.ResetReading()
+    for fid in fids:
+        lyr.DeleteFeature(fid)
+    return len(fids)
+
+
+def _append(output_gdb: str, merged_gdb: str, name: str) -> int:
+    """Bulk-append one layer from merged_gdb into output_gdb.
+
+    explodeCollections splits MultiPoint back to Point so the geometry
+    type matches the schema-clone target (geopandas promotes to multi).
+    """
+    gdal.VectorTranslate(
+        output_gdb,
+        merged_gdb,
+        options=gdal.VectorTranslateOptions(
+            layers=[name],
+            accessMode="append",
+            explodeCollections=True,
+        ),
+    )
+    ds = ogr.Open(output_gdb, 0)
+    n = ds.GetLayerByName(name).GetFeatureCount()
+    ds = None
+    return n
+
+
+def _patch(
+    output_gdb: str,
+    merged_gdb: str,
+    layers: list[str],
+    section: str,
+    log: Callable[[str], None],
+) -> list[str]:
+    errors: list[str] = []
+    log(f"\n--- {section} ---")
+    ds = ogr.Open(output_gdb, 1)
+
+    for name in layers:
+        src_ds = ogr.Open(merged_gdb, 0)
+        src_lyr = src_ds.GetLayerByName(name) if src_ds else None
+        if src_lyr is None:
+            log(f"  SKIP  {name}  (not in merged GDB)")
+            src_ds = None
+            continue
+        src_ds = None
+
+        t = time.time()
+        deleted = _truncate(ds, name)
+        if deleted == -1:
+            log(f"  WARN  {name}  (not in clone)")
+            continue
+
+        ds = None
+        try:
+            n = _append(output_gdb, merged_gdb, name)
+            log(f"  OK    {name}: {n:,}  ({time.time()-t:.1f}s)")
+        except Exception as exc:
+            msg = f"{name}: {exc}"
+            log(f"  ERR   {msg}")
+            errors.append(msg)
+
+        ds = ogr.Open(output_gdb, 1)
+
+    ds = None
+    return errors
+
+
+def patch_schema_gdb(
+    schema_gdb: Path,
+    merged_gdb: Path,
+    output_gdb: Path,
+    log: Callable[[str], None] = print,
+) -> list[str]:
+    """Clone schema_gdb, then replace its data with content from merged_gdb.
+
+    Parameters
+    ----------
+    schema_gdb:
+        Authoritative FileGDB whose schema (domains, relationships, feature
+        dataset) should be preserved — typically RC2.gdb.
+    merged_gdb:
+        Flat merged FileGDB produced by the geopandas merger.
+    output_gdb:
+        Destination path.  Deleted and recreated if it already exists.
+    log:
+        Callable used for progress reporting (default: print).
+
+    Returns
+    -------
+    list[str]
+        Error messages for layers that failed; empty on full success.
+    """
+    schema_gdb = str(schema_gdb)
+    merged_gdb = str(merged_gdb)
+    output_gdb = str(output_gdb)
+
+    # Step 1: byte-perfect clone
+    import os
+    if os.path.exists(output_gdb):
+        shutil.rmtree(output_gdb)
+
+    log(f"Cloning {schema_gdb} …")
+    t0 = time.time()
+    shutil.copytree(schema_gdb, output_gdb)
+    log(f"  done in {time.time()-t0:.1f}s")
+
+    # Drop topology layers not needed in publication
+    ds = ogr.Open(output_gdb, 1)
+    dropped: list[str] = []
+    for i in range(ds.GetLayerCount() - 1, -1, -1):
+        name = ds.GetLayerByIndex(i).GetName()
+        if name in _DROP_LAYERS or any(name.startswith(p) for p in _DROP_PREFIXES):
+            ds.DeleteLayer(i)
+            dropped.append(name)
+    ds = None
+    if dropped:
+        log(f"  dropped: {', '.join(dropped)}")
+
+    ds = ogr.Open(output_gdb, 0)
+    log(f"  layers: {ds.GetLayerCount()},  domains: {len(ds.GetFieldDomainNames() or [])}")
+    ds = None
+
+    # Step 1b: add extra fields absent from schema GDB
+    ds = ogr.Open(output_gdb, 1)
+    for layer_name in SPATIAL_LAYERS:
+        lyr = ds.GetLayerByName(layer_name)
+        if lyr is None:
+            continue
+        defn = lyr.GetLayerDefn()
+        existing = {defn.GetFieldDefn(i).GetName() for i in range(defn.GetFieldCount())}
+        for fname, ftype in _EXTRA_FIELDS:
+            if fname not in existing:
+                lyr.CreateField(ogr.FieldDefn(fname, ftype))
+                log(f"  added field '{fname}' to {layer_name}")
+    ds = None
+
+    # Steps 2 & 3: patch spatial layers and tables
+    errors: list[str] = []
+    errors += _patch(output_gdb, merged_gdb, SPATIAL_LAYERS, "Spatial layers (GC_ROCK_BODIES)", log)
+    errors += _patch(output_gdb, merged_gdb, TABLE_LAYERS,   "Tables & relationship tables", log)
+
+    ds = ogr.Open(output_gdb, 0)
+    log(f"\nDone → {output_gdb}")
+    log(f"  layers : {ds.GetLayerCount()}")
+    log(f"  domains: {len(ds.GetFieldDomainNames() or [])}")
+    ds = None
+
+    return errors

--- a/src/gcover/publish/patch_schema.py
+++ b/src/gcover/publish/patch_schema.py
@@ -77,7 +77,11 @@ def _truncate(ds: ogr.DataSource, name: str) -> int:
     lyr = ds.GetLayerByName(name)
     if lyr is None:
         return -1
+    # Skip geometry parsing — we only need FIDs, and the schema-clone source
+    # (RC2.gdb) may contain unclosed rings that OGR raises as RuntimeError.
+    lyr.SetIgnoredFields(["OGR_GEOMETRY"])
     fids = [f.GetFID() for f in lyr]
+    lyr.SetIgnoredFields([])
     lyr.ResetReading()
     for fid in fids:
         lyr.DeleteFeature(fid)


### PR DESCRIPTION
Integrated a GDAL-based schema-preservation step into the GeoCover merge pipeline so the published GDB retains ESRI domains and relationship classes