### PR TITLE
handling of `inconnu` in `spec_de/fr` fields

### DIFF
--- a/src/gcover/utils/spec_fields.py
+++ b/src/gcover/utils/spec_fields.py
@@ -13,23 +13,36 @@ from __future__ import annotations
 import geopandas as gpd
 import pandas as pd
 
-_NA: frozenset = frozenset({"not applicable", "unbekannt", "N/A", ""})
+# Hard no-data: always suppressed (even as a standalone Status/Type value)
+_NA: frozenset = frozenset({"not applicable", "N/A", ""})
+
+# Extended set used only inside _join: also strips "unknown" sentinels that
+# are noise in composite strings but acceptable as bare Status:/Type: values.
+_NA_JOIN: frozenset = _NA | {"unbekannt", "inconnu"}
 
 # Static label prefix strings keyed by language suffix
 _DEPTH_BEDR_LABEL = {"_de": "Tiefe Fels", "_fr": "Profondeur du roc"}
 
 
 def _val(v) -> str | None:
-    """Return v as a displayable string, or None for no-data sentinels."""
+    """Return v as a displayable string, or None for hard no-data sentinels."""
     if v is None or (isinstance(v, float) and pd.isna(v)):
         return None
     s = str(v).strip()
     return None if s in _NA else s or None
 
 
+def _val_join(v) -> str | None:
+    """Like _val but also strips 'unknown' sentinels (unbekannt / inconnu)."""
+    if v is None or (isinstance(v, float) and pd.isna(v)):
+        return None
+    s = str(v).strip()
+    return None if s in _NA_JOIN else s or None
+
+
 def _join(*parts) -> str | None:
-    """Comma-join non-empty display values; return None if nothing survives."""
-    items = [p for p in (_val(p) for p in parts) if p]
+    """Comma-join parts, filtering hard no-data and 'unknown' sentinels."""
+    items = [s for p in parts if (s := _val_join(p))]
     return ", ".join(items) if items else None
 
 

--- a/tests/test_translate_gpkg.py
+++ b/tests/test_translate_gpkg.py
@@ -1059,6 +1059,7 @@ class TestAddSpecFields:
     # ── sentinel / no-data filtering ──────────────────────────────────────
 
     def test_not_applicable_filtered(self):
+        """'not applicable' is always suppressed, even as a direct value."""
         gdf = _spec_gdf("linear_objects", [{
             "kind": 14901004,
             "ttec_status_de": "not applicable",
@@ -1067,14 +1068,46 @@ class TestAddSpecFields:
         result = add_spec_fields(gdf, "linear_objects")
         assert result.iloc[0]["spec_de"] is None
 
-    def test_unbekannt_filtered(self):
+    def test_unbekannt_kept_as_direct_value(self):
+        """'unbekannt' is kept when it is the sole value behind a Status: prefix."""
         gdf = _spec_gdf("surfaces", [{
             "kind": 15801001,
             "gins_main_mov_de": "unbekannt",
-            "gins_main_mov_fr": "unbekannt",
+            "gins_main_mov_fr": "inconnu",
         }])
         result = add_spec_fields(gdf, "surfaces")
+        assert result.iloc[0]["spec_de"] == "unbekannt"
+        assert result.iloc[0]["spec_fr"] == "inconnu"
+
+    def test_unbekannt_stripped_from_join(self):
+        """'unbekannt'/'inconnu' are stripped when they appear inside a joined string."""
+        gdf = _spec_gdf("point_objects", [{
+            "kind": 12501001,
+            "hsur_type_de": "unbekannt",
+            "hsur_type_fr": "inconnu",
+            "hsur_status_de": "gefasst",
+            "hsur_status_fr": "captée",
+            "hsur_flow_con_de": None,
+            "hsur_flow_con_fr": None,
+        }])
+        result = add_spec_fields(gdf, "point_objects")
+        assert result.iloc[0]["spec_de"] == "gefasst"
+        assert result.iloc[0]["spec_fr"] == "captée"
+
+    def test_all_join_parts_unbekannt_gives_null(self):
+        """If every join part is 'unbekannt'/'inconnu', the result is None."""
+        gdf = _spec_gdf("point_objects", [{
+            "kind": 12501001,
+            "hsur_type_de": "unbekannt",
+            "hsur_type_fr": "inconnu",
+            "hsur_status_de": "unbekannt",
+            "hsur_status_fr": "inconnu",
+            "hsur_flow_con_de": "unbekannt",
+            "hsur_flow_con_fr": "inconnu",
+        }])
+        result = add_spec_fields(gdf, "point_objects")
         assert result.iloc[0]["spec_de"] is None
+        assert result.iloc[0]["spec_fr"] is None
 
     def test_join_skips_none_parts(self):
         """join_parts must drop None entries; result is the surviving parts only."""


### PR DESCRIPTION
`Status: unbekannt` and `Status: inconnu` are preserved; `inconnu, époque romaine` → `époque romaine`; `inconnu, inconnu, inconnu` → `None`